### PR TITLE
Flatten detections output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Detects relevant presence in an image set.
 ## detect_images.py
 
 This script scans a directory (recursively) for images, runs YOLOv5 object detection and copies images containing persons, cars or animals to `var/detections/DATE`.
+All detected images from a run are placed directly inside that directory (the
+input directory structure is not recreated).
 
 ### Usage
 
@@ -12,4 +14,5 @@ This script scans a directory (recursively) for images, runs YOLOv5 object detec
 python3 detect_images.py /path/to/images
 ```
 
-The results will be stored in `var/detections/YYYY-MM-DD-hh-mm-ss`.
+The results will be stored in `var/detections/YYYY-MM-DD-hh-mm-ss` and all
+copied images will be saved in that folder.

--- a/detect_images.py
+++ b/detect_images.py
@@ -63,8 +63,8 @@ def main() -> None:
                 for label in detected_labels
             ):
                 relative = img_path.relative_to(src_dir)
-                destination = out_dir / relative
-                destination.parent.mkdir(parents=True, exist_ok=True)
+                flat_name = "_".join(relative.parts)
+                destination = out_dir / flat_name
                 shutil.copy2(img_path, destination)
                 copied += 1
                 print(f'Copied {img_path} -> {destination}')


### PR DESCRIPTION
## Summary
- keep all detected images from one run in the same directory
- document flattened output behaviour

## Testing
- `python3 -m py_compile detect_images.py`
- `python3 detect_images.py -h` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e667c78b88330a56d90989b33fbeb