### PR TITLE
Add confidence parameter to detection scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ expects a recent YOLOv5 release such as v7.0.
 python3 detect_images.py /path/to/images
 ```
 
+Use `--conf` to adjust the confidence threshold (default: `0.5`).
+
 
 The results will be stored in `var/detections/YYYY-MM-DD-hh-mm-ss`.
 
@@ -40,6 +42,8 @@ detecciones.
 ```bash
 python usb_images_presence_detector.py
 ```
+
+You can also set a confidence threshold with `--conf` (default: `0.5`).
 
 Al finalizar se muestran estadísticas de las imágenes procesadas y las
 detecciones encontradas.

--- a/detect_images.py
+++ b/detect_images.py
@@ -21,6 +21,12 @@ def parse_args():
         description='Detect persons, cars and animals in images and copy them to var/detections/YYYY-MM-DD-hh-mm-ss inside the project directory.'
     )
     parser.add_argument('directory', help='Directory to search for images recursively')
+    parser.add_argument(
+        '--conf',
+        type=float,
+        default=0.5,
+        help='Confidence threshold for detections'
+    )
     return parser.parse_args()
 
 
@@ -45,6 +51,7 @@ def main() -> None:
     model = torch.hub.load(
         'ultralytics/yolov5:v7.0', 'yolov5s', pretrained=True
     )
+    model.conf = args.conf
 
     copied = 0
     for root, _, files in os.walk(src_dir):

--- a/usb_images_presence_detector.py
+++ b/usb_images_presence_detector.py
@@ -74,9 +74,10 @@ def is_image(filename: str) -> bool:
     )
 
 
-def detect_images(root_dir: Path, out_dir: Path):
+def detect_images(root_dir: Path, out_dir: Path, conf: float):
     print('Loading model...')
     model = torch.hub.load('ultralytics/yolov5', 'yolov5s', pretrained=True)
+    model.conf = conf
 
     processed = 0
     skipped = 0
@@ -125,11 +126,17 @@ def detect_images(root_dir: Path, out_dir: Path):
 
 def main():
     parser = argparse.ArgumentParser(description='USB Images Presence Detector')
-    parser.parse_args()  # For symmetry, no args currently
+    parser.add_argument(
+        '--conf',
+        type=float,
+        default=0.5,
+        help='Confidence threshold for detections'
+    )
+    args = parser.parse_args()
     drives = get_external_drives()
     drive = choose_drive(drives)
     out_dir = ask_output_directory()
-    detect_images(Path(drive), out_dir)
+    detect_images(Path(drive), out_dir, args.conf)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow setting YOLO detection confidence for `detect_images.py`
- allow setting YOLO detection confidence for `usb_images_presence_detector.py`
- document `--conf` option in README

## Testing
- `python -m py_compile detect_images.py usb_images_presence_detector.py`
- `python detect_images.py -h` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e8d3edadc8330a5977a5594dc6161